### PR TITLE
tinder should require 'uri' in cases where it isn't already loaded

### DIFF
--- a/lib/tinder/connection.rb
+++ b/lib/tinder/connection.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'faraday'
 
 module Tinder


### PR DESCRIPTION
running tinder from irb, I get the following uh-oh:

```
[16:17][:/tmp/tinder(master)]$ irb
>> require 'tinder'
=> true
>> campfire = Tinder::Campfire.new 'mysubdomain', :token => '...'
NameError: uninitialized constant Tinder::Connection::URI
  from /Library/Ruby/Gems/1.8/gems/tinder-1.4.2/lib/tinder/connection.rb:33:in `initialize'
  from /Library/Ruby/Gems/1.8/gems/tinder-1.4.2/lib/tinder/campfire.rb:25:in `new'
  from /Library/Ruby/Gems/1.8/gems/tinder-1.4.2/lib/tinder/campfire.rb:25:in `initialize'
  from (irb):2:in `new'
  from (irb):2
```

This simple patch fixes that.
