### PR TITLE
Enable :ssl_verify => false option on initialize 

### DIFF
--- a/lib/tinder/campfire.rb
+++ b/lib/tinder/campfire.rb
@@ -18,6 +18,8 @@ module Tinder
     # == Options:
     # * +:ssl+: use SSL for the connection, which is required if you have a Campfire SSL account.
     #           Defaults to false
+    # * +:ssl_verify+: verify SSL certificate using if using SSL
+    #           Defaults to true
     # * +:proxy+: a proxy URI. (e.g. :proxy => 'http://user:pass@example.com:8000')
     #
     #   c = Tinder::Campfire.new("mysubdomain", :ssl => true)

--- a/lib/tinder/connection.rb
+++ b/lib/tinder/connection.rb
@@ -30,7 +30,7 @@ module Tinder
 
     def initialize(subdomain, options = {})
       @subdomain = subdomain
-      @options = { :ssl => true, :proxy => ENV['HTTP_PROXY'] }.merge(options)
+      @options = { :ssl => true, :ssl_verify => true, :proxy => ENV['HTTP_PROXY'] }.merge(options)
       @uri = URI.parse("#{@options[:ssl] ? 'https' : 'http' }://#{subdomain}.#{HOST}")
       @token = options[:token]
 
@@ -47,6 +47,9 @@ module Tinder
         conn = self.class.connection.dup
         conn.url_prefix = @uri.to_s
         conn.proxy options[:proxy]
+        if options[:ssl_verify] == false
+          conn.ssl[:verify] = false
+        end
         conn
       end
     end
@@ -56,6 +59,9 @@ module Tinder
         conn = self.class.raw_connection.dup
         conn.url_prefix = @uri.to_s
         conn.proxy options[:proxy]
+        if options[:ssl_verify] == false
+          conn.ssl[:verify] = false
+        end
         conn
       end
     end


### PR DESCRIPTION
We had some issues where we wanted to keep SSL on but disable the cert verification.

Faraday supports all of the verification methods in OpenSSL::SSL::VERIFY_*, but I chose not to expose these in favor of 'on' (use Net/HTTPS default VERIFY_PEER) / 'off' (VERIFY_NONE).

https://github.com/technoweenie/faraday/blob/master/lib/faraday/adapter/net_http.rb#L19

Thanks!
