### PR TITLE
We provide 1.9.3[-preview1] at travis-ci.org, rbx-2.0 will soon replace m

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 rvm:
   - 1.8.7
   - 1.9.2
+  - 1.9.3
   - ruby-head
-  - rbx
+  - rbx-2.0
   - jruby
 only:
   - master


### PR DESCRIPTION
We provide 1.9.3[-preview1] at travis-ci.org, rbx-2.0 will soon replace master
