### PR TITLE
allow passing any ssl options to the faraday connection

### DIFF
--- a/lib/tinder/campfire.rb
+++ b/lib/tinder/campfire.rb
@@ -19,8 +19,8 @@ module Tinder
     # == Options:
     # * +:ssl+: use SSL for the connection, which is required if you have a Campfire SSL account.
     #           Defaults to true
-    # * +:ssl_verify+: verify SSL certificate if using SSL
-    #           Defaults to true
+    # * +:ssl_options+: SSL options passed to the underlaying Faraday connection. Allows to specify if the SSL certificate should be verified (:verify => true|false) and to specify the path to the ssl certs directory (:ca_path => "path/certs")
+    #           Defaults to {:verify => true}
     # * +:proxy+: a proxy URI. (e.g. :proxy => 'http://user:pass@example.com:8000')
     #
     #   c = Tinder::Campfire.new("mysubdomain", :ssl => true)

--- a/lib/tinder/connection.rb
+++ b/lib/tinder/connection.rb
@@ -35,7 +35,11 @@ module Tinder
 
     def initialize(subdomain, options = {})
       @subdomain = subdomain
-      @options = {:ssl => true, :ssl_verify => true, :proxy => ENV['HTTP_PROXY']}.merge(options)
+
+      @options = {:ssl => true, :ssl_options => {:verify => true}, :proxy => ENV['HTTP_PROXY']}
+      @options[:ssl_options][:verify] = options.delete(:ssl_verify) unless options[:ssl_verify].nil?
+      @options.merge!(options)
+
       @uri = URI.parse("#{@options[:ssl] ? 'https' : 'http' }://#{subdomain}.#{HOST}")
       @token = options[:token]
 
@@ -52,8 +56,8 @@ module Tinder
         conn = self.class.connection.dup
         conn.url_prefix = @uri.to_s
         conn.proxy options[:proxy]
-        if options[:ssl_verify] == false
-          conn.ssl[:verify] = false
+        if options[:ssl_options]
+          conn.ssl.merge!(options[:ssl_options])
         end
         conn
       end
@@ -64,8 +68,8 @@ module Tinder
         conn = self.class.raw_connection.dup
         conn.url_prefix = @uri.to_s
         conn.proxy options[:proxy]
-        if options[:ssl_verify] == false
-          conn.ssl[:verify] = false
+        if options[:ssl_options]
+          conn.ssl.merge!(options[:ssl_options])
         end
         conn
       end

--- a/spec/tinder/connection_spec.rb
+++ b/spec/tinder/connection_spec.rb
@@ -48,5 +48,13 @@ describe Tinder::Connection do
       connection = Tinder::Connection.new('test', :username => 'user', :password => 'pass', :ssl_verify => false)
       connection.connection.ssl[:verify].should be == false
     end
+
+    it "should allow passing any ssl_options to Faraday" do
+      stub_connection(Tinder::Connection) do |stub|
+        stub.get("/users/me.json") {[200, {}, fixture('users/me.json')]}
+      end
+      connection = Tinder::Connection.new('test', :username => 'user', :password => 'pass', :ssl_options => {:verify => false, :ca_path => "/usr/lib/ssl/certs"})
+      connection.connection.ssl.should eql(:verify => false, :ca_path => "/usr/lib/ssl/certs")
+    end
   end
 end


### PR DESCRIPTION
This change allows to set ssl options on the underlaying faraday connection by passing a :ssl_options hash to Campfire.new(). 
This is needed to specify the :ca_path option which tells Faraday where the CA certificates are located. 
Without this option verifying the SSL cert may not be possible because  root certificates can not be found.

related faraday wiki entry:
https://github.com/technoweenie/faraday/wiki/Setting-up-SSL-certificates

The currently :ssl_verify is still supported. 
