### PR TITLE
Allow ca_file and ca_path to be set

### DIFF
--- a/lib/tinder/connection.rb
+++ b/lib/tinder/connection.rb
@@ -35,7 +35,7 @@ module Tinder
 
     def initialize(subdomain, options = {})
       @subdomain = subdomain
-      @options = {:ssl => true, :ssl_verify => true, :proxy => ENV['HTTP_PROXY']}.merge(options)
+      @options = {:ssl => true, :proxy => ENV['HTTP_PROXY']}.merge(options)
       @uri = URI.parse("#{@options[:ssl] ? 'https' : 'http' }://#{subdomain}.#{HOST}")
       @token = options[:token]
 
@@ -50,11 +50,7 @@ module Tinder
     def connection
       @connection ||= begin
         conn = self.class.connection.dup
-        conn.url_prefix = @uri.to_s
-        conn.proxy options[:proxy]
-        if options[:ssl_verify] == false
-          conn.ssl[:verify] = false
-        end
+        set_connection_options(conn)
         conn
       end
     end
@@ -62,11 +58,7 @@ module Tinder
     def raw_connection
       @raw_connection ||= begin
         conn = self.class.raw_connection.dup
-        conn.url_prefix = @uri.to_s
-        conn.proxy options[:proxy]
-        if options[:ssl_verify] == false
-          conn.ssl[:verify] = false
-        end
+        set_connection_options(conn)
         conn
       end
     end
@@ -101,5 +93,17 @@ module Tinder
     def ssl?
       uri.scheme == 'https'
     end
+    
+    private
+    
+      def set_connection_options(conn)
+        conn.url_prefix = @uri.to_s
+        conn.proxy options[:proxy]
+        if options[:ssl_verify] == false
+          conn.ssl[:verify] = false
+        end
+        conn.ssl[:ca_path] = options[:ca_path] if options[:ca_path]
+        conn.ssl[:ca_file] = options[:ca_file] if options[:ca_file]
+      end
   end
 end

--- a/spec/tinder/connection_spec.rb
+++ b/spec/tinder/connection_spec.rb
@@ -48,5 +48,17 @@ describe Tinder::Connection do
       connection = Tinder::Connection.new('test', :username => 'user', :password => 'pass', :ssl_verify => false)
       connection.connection.ssl[:verify].should be == false
     end
+    
+    it 'should allow ca_path to be set' do
+      ca_path = "/etc/ssl/custom"
+      connection = Tinder::Connection.new('test', :ca_path => ca_path)
+      connection.connection.ssl[:ca_path].should == ca_path
+    end
+    
+    it 'should allow ca_file to be set' do
+      ca_file = "/etc/ssl/custom"
+      connection = Tinder::Connection.new('test', :ca_file => ca_file)
+      connection.connection.ssl[:ca_file].should == ca_file
+    end
   end
 end


### PR DESCRIPTION
Patch adds the ability to set ssl ca_file and ca_path options. (Use instead of setting ssl_verify => false)

However, I'm wondering if it wouldn't be better to just let :ssl => { ... options ... } be passed to Tinder.new instead of proxying each of these options individually.
