### PR TITLE
Treat an invalid subdomain as an authentication failure

### DIFF
--- a/lib/faraday/response/raise_on_authentication_failure.rb
+++ b/lib/faraday/response/raise_on_authentication_failure.rb
@@ -4,7 +4,7 @@ require 'faraday'
 module Faraday
   class Response::RaiseOnAuthenticationFailure < Response::Middleware
     def on_complete(response)
-      raise Tinder::AuthenticationFailed if response[:status] == 401
+      raise Tinder::AuthenticationFailed if [401, 404].include?(response[:status])
     end
   end
 end

--- a/spec/tinder/connection_spec.rb
+++ b/spec/tinder/connection_spec.rb
@@ -12,6 +12,15 @@ describe Tinder::Connection do
       lambda { connection.get('/rooms.json') }.should raise_error(Tinder::AuthenticationFailed)
     end
 
+    it "should raise an exception when an invalid subdomain is specified" do
+      stub_connection(Tinder::Connection) do |stub|
+        stub.get("/rooms.json") {[404, {}, "Not found"]}
+      end
+
+      connection = Tinder::Connection.new('test', :token => 'foo')
+      lambda { connection.get('/rooms.json') }.should raise_error(Tinder::AuthenticationFailed)
+    end
+
     it "should lookup token when username/password provided" do
       stub_connection(Tinder::Connection) do |stub|
         stub.get("/users/me.json") {[200, {}, fixture('users/me.json')]}


### PR DESCRIPTION
37signals recently updated their Campfire API so that it now returns a 404 status when attempting to access a nonexistent subdomain. However, the extension of Faraday is only treating 401 status codes as authentication failures. 

This patch will cause Faraday to raise a Tinder::AuthenticationFailed exception for a 401 or 404 status codes in the response accordingly.
