### PR TITLE
Fix rbx mode for Travis-Ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: ruby
 rvm:
   - 1.8.7
   - 1.9.2


### PR DESCRIPTION
I saw the build was failing, but only for rbx 2.0. Travis docs say 19mode is pulling from 2.0 branch and is very close. I forked tinder, set it up on travis, and now all tests pass, including rbx19mode.
