### PR TITLE
Typecast id in find_room_by_id

### DIFF
--- a/lib/tinder/campfire.rb
+++ b/lib/tinder/campfire.rb
@@ -37,7 +37,9 @@ module Tinder
     end
 
     # Find a campfire room by id
+    # NOTE: id should be of type Integer
     def find_room_by_id(id)
+      id = id.to_i
       rooms.detect { |room| room.id == id }
     end
 


### PR DESCRIPTION
find_room_by_id will fail to find a room given a valid id as a String.
It seems like a useful convenience to typecast the parameter.
