### PR TITLE
Add in support for OAuth authentication

### DIFF
--- a/lib/tinder/connection.rb
+++ b/lib/tinder/connection.rb
@@ -40,9 +40,15 @@ module Tinder
       @options.merge!(options)
       @uri = URI.parse("#{@options[:ssl] ? 'https' : 'http' }://#{subdomain}.#{HOST}")
       @token = options[:token]
+      @oauth_token = options[:oauth_token]
 
-      connection.basic_auth token, 'X'
-      raw_connection.basic_auth token, 'X'
+      if @oauth_token
+        connection.headers["Authorization"] = "Bearer #{@oauth_token}"
+        raw_connection.headers["Authorization"] = "Bearer #{@oauth_token}"
+      else
+        connection.basic_auth token, 'X'
+        raw_connection.basic_auth token, 'X'
+      end
     end
 
     def basic_auth_settings

--- a/spec/tinder/connection_spec.rb
+++ b/spec/tinder/connection_spec.rb
@@ -37,6 +37,33 @@ describe Tinder::Connection do
       connection = Tinder::Connection.new('test', :token => 'mytoken')
       lambda { connection.get('/rooms.json') }.should_not raise_error
     end
+
+  end
+
+  describe "oauth" do
+    let (:oauth_token) { "myoauthtoken" }
+    let (:connection) { Tinder::Connection.new('test', :oauth_token => oauth_token) }
+
+    before do
+      stub_connection(Tinder::Connection) do |stub|
+        stub.get("/rooms.json") {[200, {}, fixture('rooms.json')]}
+      end
+    end
+
+    it "should authenticate" do
+      lambda { connection.get('/rooms.json') }.should_not raise_error
+    end
+
+    it "should set the oauth_token" do
+      connection.get('/rooms.json')
+      connection.options[:oauth_token].should == oauth_token
+    end
+
+    it "should set an Authorization header" do
+      connection.get('/rooms.json')
+      connection.connection.headers["Authorization"].should == "Bearer #{oauth_token}"
+    end
+
   end
 
   describe "ssl" do


### PR DESCRIPTION
The old Campfire API only supported basic HTTP authentication, the new one supports OAuth. If you have obtained an OAuth token from the main 37Signals API then you can use that same token to access any campfire room that the token has access to. 

Basic HTTP Authentication details: https://github.com/37signals/campfire-api#authentication

OAuth: https://github.com/37signals/api/blob/master/sections/authentication.md#oauth-2-from-scratch

This adds in the option to specify :oauth_token when creating a connection which then sets a header of "Authorization: Bearer #{oauth_token}" instead of using basic HTTP authentication.
