### PR TITLE
Add in 'type' attribute to transcript results

### DIFF
--- a/lib/tinder/room.rb
+++ b/lib/tinder/room.rb
@@ -186,7 +186,7 @@ module Tinder
 
     # Get the transcript for the given date (Returns a hash in the same format as #listen)
     #
-    #   room.transcript(room.available_transcripts.first)
+    #   room.transcript(Time.now)
     #   #=> [{:message=>"foobar!",
     #         :user_id=>"99999",
     #         :person=>"Brandon",
@@ -196,12 +196,9 @@ module Tinder
     # The timestamp slot will typically have a granularity of five minutes.
     #
     def transcript(transcript_date)
-      url = "/room/#{@id}/transcript/#{transcript_date.to_date.strftime('%Y/%m/%d')}.json"
+      url = "/room/#{@id}/transcript/#{transcript_date.strftime('%Y/%m/%d')}.json"
       connection.get(url)['messages'].map do |room|
-        { :id => room['id'],
-          :user_id => room['user_id'],
-          :message => room['body'],
-          :timestamp => Time.parse(room['created_at']) }
+        map_room_attributes(room)
       end
     end
 
@@ -222,10 +219,7 @@ module Tinder
       end
 
       room_messages.map do |room|
-        { :id => room['id'],
-          :user_id => room['user_id'],
-          :message => room['body'],
-          :timestamp => Time.parse(room['created_at']) }
+        map_room_attributes(room)
       end
     end
 
@@ -297,6 +291,14 @@ module Tinder
 
     def connection
       @connection
+    end
+
+    def map_room_attributes(room)
+      { :id => room['id'],
+        :user_id => room['user_id'],
+        :message => room['body'],
+        :type => room['type'],
+        :timestamp => Time.parse(room['created_at']) }
     end
   end
 end

--- a/spec/tinder/room_spec.rb
+++ b/spec/tinder/room_spec.rb
@@ -204,6 +204,29 @@ describe Tinder::Room do
     end
   end
 
+  describe "transcript" do
+    before do
+      stub_connection(@connection) do |stub|
+        stub.get("/room/80749/transcript/#{Time.now.strftime('%Y/%m/%d')}.json") {[
+          200, {}, fixture('rooms/recent.json')
+        ]}
+      end
+    end
+
+    it "should return an array of messages" do
+      @room.transcript(Time.now).should be_a(Array)
+    end
+
+    it "should have messages with attributes" do
+      message = @room.transcript(Time.now).first
+
+      message[:id].should be_a(Integer)
+      message[:user_id].should be_a(Integer)
+      message[:message].should be_a(String)
+      message[:timestamp].should be_a(Time)
+    end
+  end
+
   describe "recent" do
     before do
       stub_connection(@connection) do |stub|


### PR DESCRIPTION
Mapped the 'type' attribute from messages to the hash so that you can use that now. I noticed the comments mentioned some older functionality(<code>room.available_transcripts</code>) so I removed that and just supplied <code>Time.now</code>. 
