### PR TITLE
WIP: Add support for Faraday v0.9.0 (rc5)

### DIFF
--- a/lib/tinder/connection.rb
+++ b/lib/tinder/connection.rb
@@ -1,10 +1,15 @@
 # encoding: UTF-8
 require 'faraday'
+require 'faraday/request/multipart'
 require 'faraday/response/raise_on_authentication_failure'
 require 'faraday/response/remove_whitespace'
 require 'faraday_middleware'
 require 'json'
 require 'uri'
+
+class Faraday::RequestOptions
+  attr_accessor :preserve_raw
+end
 
 module Tinder
   class Connection

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'rspec'
 require 'tinder'
 require 'fakeweb'
 
+require 'faraday/adapter/test'
+
 FakeWeb.allow_net_connect = false
 
 def fixture(name)

--- a/spec/tinder/connection_spec.rb
+++ b/spec/tinder/connection_spec.rb
@@ -82,7 +82,7 @@ describe Tinder::Connection do
       end
 
       connection = Tinder::Connection.new('test', :username => 'user', :password => 'pass', :ssl_verify => false)
-      connection.connection.ssl[:verify].should be == false
+      connection.connection.ssl.verify?.should be == false
     end
 
     it "should allow passing any ssl_options to Faraday" do
@@ -98,7 +98,7 @@ describe Tinder::Connection do
           :ca_file => "/etc/ssl/custom"
         }
       )
-      connection.connection.ssl.should eql(:verify => false, :ca_path => "/usr/lib/ssl/certs", :ca_file => "/etc/ssl/custom")
+      connection.connection.ssl.to_hash.should eql(:verify => false, :ca_path => "/usr/lib/ssl/certs", :ca_file => "/etc/ssl/custom")
     end
   end
 end

--- a/tinder.gemspec
+++ b/tinder.gemspec
@@ -4,7 +4,7 @@ require 'tinder/version'
 
 Gem::Specification.new do |gem|
   gem.add_dependency 'eventmachine', '~> 1.0'
-  gem.add_dependency 'faraday', '~> 0.8'
+  gem.add_dependency 'faraday', '~> 0.9.0.rc5'
   gem.add_dependency 'faraday_middleware', '~> 0.9'
   gem.add_dependency 'hashie', ['>= 1.0', '< 3']
   gem.add_dependency 'json', '~> 1.7.5'


### PR DESCRIPTION
The only gross thing is adding `Faraday::RequestOptions#preserve_raw`.  Do you need this behavior from FaradayMiddleware?
