### PR TITLE
upgrading json and multi_json gem versions on which tinder depends. Also modified specs to remove deprecation warinings

### DIFF
--- a/lib/tinder/version.rb
+++ b/lib/tinder/version.rb
@@ -1,4 +1,4 @@
 # encoding: UTF-8
 module Tinder
-  VERSION = '1.9.2' unless defined?(::Tinder::VERSION)
+  VERSION = '1.9.3' unless defined?(::Tinder::VERSION)
 end

--- a/spec/tinder/room_spec.rb
+++ b/spec/tinder/room_spec.rb
@@ -15,11 +15,11 @@ describe Tinder::Room do
     # Get EventMachine out of the way. We could be using em-spec, but seems like overkill
     require 'twitter/json_stream'
     module EventMachine; def self.run; yield end end
-    EventMachine.stub!(:reactor_running?).and_return(true)
-    @stream = mock(Twitter::JSONStream)
-    @stream.stub!(:each_item)
-    @stream.stub!(:on_error)
-    @stream.stub!(:on_max_reconnects)
+    EventMachine.stub(:reactor_running?).and_return(true)
+    @stream = double(Twitter::JSONStream)
+    @stream.stub(:each_item)
+    @stream.stub(:on_error)
+    @stream.stub(:on_max_reconnects)
   end
 
   describe "join" do
@@ -115,12 +115,12 @@ describe Tinder::Room do
 
   describe "guest_url" do
     it "should use guest_invite_code if active" do
-      @room.stub!(:guest_access_enabled? => true, :guest_invite_code => '123')
+      @room.stub(:guest_access_enabled? => true, :guest_invite_code => '123')
       @room.guest_url.should == "https://test.campfirenow.com/123"
     end
 
     it "should return nil when guest access is not enabled" do
-      @room.stub!(:guest_access_enabled?).and_return(false)
+      @room.stub(:guest_access_enabled?).and_return(false)
       @room.guest_url.should be_nil
     end
   end
@@ -194,7 +194,7 @@ describe Tinder::Room do
     end
 
     it "marks the room as listening" do
-      Twitter::JSONStream.stub!(:connect).and_return(@stream)
+      Twitter::JSONStream.stub(:connect).and_return(@stream)
       lambda {
         @room.listen { }
       }.should change(@room, :listening?).from(false).to(true)
@@ -207,8 +207,8 @@ describe Tinder::Room do
         stub.post('/room/80749/join.json') {[200, {}, ""]}
       end
 
-      Twitter::JSONStream.stub!(:connect).and_return(@stream)
-      @stream.stub!(:stop)
+      Twitter::JSONStream.stub(:connect).and_return(@stream)
+      @stream.stub(:stop)
     end
 
     it "changes a listening room to a non-listening room" do

--- a/tinder.gemspec
+++ b/tinder.gemspec
@@ -7,9 +7,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.8'
   gem.add_dependency 'faraday_middleware', '~> 0.9'
   gem.add_dependency 'hashie', ['>= 1.0', '< 3']
-  gem.add_dependency 'json', '~> 1.7.5'
+  gem.add_dependency 'json', '~> 1.8.0'
   gem.add_dependency 'mime-types', '~> 1.19'
-  gem.add_dependency 'multi_json', '~> 1.5'
+  gem.add_dependency 'multi_json', '~> 1.7'
   gem.add_dependency 'twitter-stream', '~> 0.1'
 
   gem.add_development_dependency 'fakeweb'


### PR DESCRIPTION
Since Json gem version 1.7.7 has become a base version for most common usage, it is necessary to upgrade the version of json gem that tinder depends on. Since the current version is 1.8, am changing it to the most recent version. Not sure if this warrents a minor version number upgrade. but have changed the version number to 1.9.3 anyways!
