### PR TITLE
Fixes 'warning: assigned but unused variable - response'

### DIFF
--- a/lib/tinder/connection.rb
+++ b/lib/tinder/connection.rb
@@ -95,7 +95,7 @@ module Tinder
     end
 
     def raw_post(url, body = nil, *args)
-      response = raw_connection.post(url, body, *args)
+      raw_connection.post(url, body, *args)
     end
 
     def put(url, body = nil, *args)


### PR DESCRIPTION
Minimal steps to reproduce:

```
$ gem install tinder
$ echo "require 'tinder'" >> tinder_test.rb
$ ruby -w tinder_test.rb
... ruby/2.3.1/gems/tinder-1.10.1/lib/tinder/connection.rb:98: warning: assigned but unused variable - response
```